### PR TITLE
External python client for testing

### DIFF
--- a/AV00-Tests/AV00-Tests.csproj
+++ b/AV00-Tests/AV00-Tests.csproj
@@ -17,4 +17,8 @@
     <PackageReference Include="coverlet.collector" Version="6.0.0" />
   </ItemGroup>
 
+  <ItemGroup>
+    <Folder Include="PythonTestClient\" />
+  </ItemGroup>
+
 </Project>

--- a/AV00-Tests/PythonTestClient/motor_event.py
+++ b/AV00-Tests/PythonTestClient/motor_event.py
@@ -16,17 +16,16 @@ class EnumMotorCommands(int, Enum):
 
 class MotorDirection:
     # PinValues
-    Forwards = {};
-    Backwards = {};
-    Left = {};
-    Right = {};
+    Forwards = "High"
+    Backwards = "Low"
+    Left = "High"
+    Right = "Low"
 
     def __init__(self):
-        self.Forwards = {};
-        self.Backwards = {};
-        self.Left = {};
-        self.Right = {};
-
+        self.Forwards = "High"
+        self.Backwards = "Low"
+        self.Left = "High"
+        self.Right = "Low"
 
 class Event:
 

--- a/AV00-Tests/PythonTestClient/motor_event.py
+++ b/AV00-Tests/PythonTestClient/motor_event.py
@@ -14,18 +14,19 @@ class EnumMotorCommands(int, Enum):
     Turn = 1
 
 
+class EnumMotorDirection(int, Enum):
+    Low = 0
+    High = 1
+
+
 class MotorDirection:
-    # PinValues
-    #Forwards = "High"
-    #Backwards = "Low"
-    #Left = "High"
-    #Right = "Low"
 
     def __init__(self):
-        self.Forwards = 1
-        self.Backwards = 0
-        self.Left = 0
-        self.Right = 1
+        self.Forwards = EnumMotorDirection.High
+        self.Backwards = EnumMotorDirection.Low
+        self.Left = EnumMotorDirection.High
+        self.Right = EnumMotorDirection.Low
+
 
 class Event:
 

--- a/AV00-Tests/PythonTestClient/motor_event.py
+++ b/AV00-Tests/PythonTestClient/motor_event.py
@@ -20,12 +20,14 @@ class Event:
         self.motor_event = motor_event
        
     def serialize(self):
-        return [
-            self.motor_event.service_name,
-            EnumEventType.Event,
+        temp = [
+            str.encode(self.motor_event.service_name),
+            EnumEventType(0).name,
             self.motor_event._id,
             json.dumps(self.motor_event.to_dict())
         ]
+        print(temp)
+        return temp
 
 
 class MotorEvent:

--- a/AV00-Tests/PythonTestClient/motor_event.py
+++ b/AV00-Tests/PythonTestClient/motor_event.py
@@ -21,6 +21,12 @@ class MotorDirection:
     Left = {};
     Right = {};
 
+    def __init__(self):
+        self.Forwards = {};
+        self.Backwards = {};
+        self.Left = {};
+        self.Right = {};
+
 
 class Event:
 

--- a/AV00-Tests/PythonTestClient/motor_event.py
+++ b/AV00-Tests/PythonTestClient/motor_event.py
@@ -1,0 +1,13 @@
+import uuid
+
+class MotorEvent:
+    
+    def __init__(ServiceName, Command, Direction, PwmAmount, Mode):
+        # command = EnumMotorCommands
+        # mode = EnumExecutionMode.Blocking
+        direction = Direction
+        pwm_amount = PwmAmount
+        command = Command
+        mode = Mode
+        _id = uuid.uuid4()
+        timestamp = "fake-time-stamp"

--- a/AV00-Tests/PythonTestClient/motor_event.py
+++ b/AV00-Tests/PythonTestClient/motor_event.py
@@ -1,13 +1,52 @@
 import uuid
+import json
+from enum import Enum
+
+
+class EnumEventType(Enum):
+    Event = 0
+    EventReceipt = 1
+    EventLog = 2
+
+
+class EnumMotorCommands(Enum):
+    Move = 0
+    Turn = 1
+
+
+class Event:
+
+    def __init__(self, motor_event):
+        self.motor_event = motor_event
+       
+    def serialize(self):
+        return [
+            self.motor_event.service_name,
+            EnumEventType.Event,
+            self.motor_event._id,
+            json.dumps(self.motor_event.to_dict())
+        ]
+
 
 class MotorEvent:
     
-    def __init__(ServiceName, Command, Direction, PwmAmount, Mode):
-        # command = EnumMotorCommands
+    def __init__(self, ServiceName, Command, Direction, PwmAmount, Mode=0):
         # mode = EnumExecutionMode.Blocking
-        direction = Direction
-        pwm_amount = PwmAmount
-        command = Command
-        mode = Mode
-        _id = uuid.uuid4()
-        timestamp = "fake-time-stamp"
+        self.service_name = ServiceName
+        self.direction = Direction
+        self.pwm_amount = PwmAmount
+        self.command = Command
+        self.mode = Mode
+        self._id = uuid.uuid4()
+        self.timestamp = "fake-time-stamp"
+    
+    def to_dict(self):
+        return {
+            "ServiceName": self.service_name,
+            "Command": self.command,
+            "Direction": self.direction,
+            "PwmAmount": self.pwm_amount,
+            "EnumExecutionMode": self.mode,
+            "Id": self._id,
+            "TimeStamp": self.timestamp,
+        }

--- a/AV00-Tests/PythonTestClient/motor_event.py
+++ b/AV00-Tests/PythonTestClient/motor_event.py
@@ -14,6 +14,14 @@ class EnumMotorCommands(int, Enum):
     Turn = 1
 
 
+class MotorDirection:
+    # PinValues
+    Forwards = {};
+    Backwards = {};
+    Left = {};
+    Right = {};
+
+
 class Event:
 
     def __init__(self, motor_event):
@@ -24,7 +32,7 @@ class Event:
             str.encode(self.motor_event.service_name),
             str.encode(EnumEventType(0).name),
             str.encode(self.motor_event._id),
-            json.dumps(self.motor_event.to_dict())
+            str.encode(json.dumps(self.motor_event.to_dict()))
         ]
         print(temp)
         return temp

--- a/AV00-Tests/PythonTestClient/motor_event.py
+++ b/AV00-Tests/PythonTestClient/motor_event.py
@@ -62,7 +62,7 @@ class MotorEvent:
             "Command": self.command,
             "Direction": self.direction,
             "PwmAmount": self.pwm_amount,
-            "EnumExecutionMode": self.mode,
+            "Mode": self.mode,
             "Id": self._id,
             "TimeStamp": self.timestamp,
         }

--- a/AV00-Tests/PythonTestClient/motor_event.py
+++ b/AV00-Tests/PythonTestClient/motor_event.py
@@ -16,16 +16,16 @@ class EnumMotorCommands(int, Enum):
 
 class MotorDirection:
     # PinValues
-    Forwards = "High"
-    Backwards = "Low"
-    Left = "High"
-    Right = "Low"
+    #Forwards = "High"
+    #Backwards = "Low"
+    #Left = "High"
+    #Right = "Low"
 
     def __init__(self):
-        self.Forwards = "High"
-        self.Backwards = "Low"
-        self.Left = "High"
-        self.Right = "Low"
+        self.Forwards = 1
+        self.Backwards = 0
+        self.Left = 0
+        self.Right = 1
 
 class Event:
 

--- a/AV00-Tests/PythonTestClient/motor_event.py
+++ b/AV00-Tests/PythonTestClient/motor_event.py
@@ -22,8 +22,8 @@ class Event:
     def serialize(self):
         temp = [
             str.encode(self.motor_event.service_name),
-            EnumEventType(0).name,
-            self.motor_event._id,
+            str.encode(EnumEventType(0).name),
+            str.encode(self.motor_event._id),
             json.dumps(self.motor_event.to_dict())
         ]
         print(temp)
@@ -39,7 +39,7 @@ class MotorEvent:
         self.pwm_amount = PwmAmount
         self.command = Command
         self.mode = Mode
-        self._id = uuid.uuid4()
+        self._id =  str(uuid.uuid4())
         self.timestamp = "fake-time-stamp"
     
     def to_dict(self):
@@ -49,6 +49,6 @@ class MotorEvent:
             "Direction": self.direction,
             "PwmAmount": self.pwm_amount,
             "EnumExecutionMode": self.mode,
-            "Id": str(self._id),
+            "Id": self._id,
             "TimeStamp": self.timestamp,
         }

--- a/AV00-Tests/PythonTestClient/motor_event.py
+++ b/AV00-Tests/PythonTestClient/motor_event.py
@@ -3,13 +3,13 @@ import json
 from enum import Enum
 
 
-class EnumEventType(Enum):
+class EnumEventType(int, Enum):
     Event = 0
     EventReceipt = 1
     EventLog = 2
 
 
-class EnumMotorCommands(Enum):
+class EnumMotorCommands(int, Enum):
     Move = 0
     Turn = 1
 
@@ -47,6 +47,6 @@ class MotorEvent:
             "Direction": self.direction,
             "PwmAmount": self.pwm_amount,
             "EnumExecutionMode": self.mode,
-            "Id": self._id,
+            "Id": str(self._id),
             "TimeStamp": self.timestamp,
         }

--- a/AV00-Tests/PythonTestClient/motor_test_client.py
+++ b/AV00-Tests/PythonTestClient/motor_test_client.py
@@ -1,7 +1,33 @@
 
+from os import name
 import zmq
 import time
+import argparse
 from motor_event import *
+
+
+class CLI:
+    
+    def __init__(self):
+        self.parser = argparse.ArgumentParser()
+
+    def configure_arguments(self):
+        self.parser.add_argument(
+            "-c",
+            "--command",
+            choices=["Move", "Turn"] 
+        )
+        self.parser.add_argument(
+            "-d",
+            "--direction",
+            choices=[e.name for e in MotorDirection]
+        )
+        self.parser.add_argument(
+            "-p",
+            "--power",
+            help="Float between 0 and 100"
+        )
+        self.args = self.parser.parse_args()
 
 
 class RelayClient:
@@ -23,13 +49,16 @@ class main:
 
 
 if __name__ == "__main__":
+    cli = CLI()
+    cli.configure_arguments()
+    
     relay_client = RelayClient()
     
     motor_event = MotorEvent(
          ServiceName="DriveService",
-         Command=EnumMotorCommands.Move,
+         Command=EnumMotorCommands(cli.args["comman"]),
          Direction={},
-         PwmAmount=30.0,
+         PwmAmount=cli.args["power"],
     )
     relay_client.send_motor_event(motor_event)    
     time.sleep(1)

--- a/AV00-Tests/PythonTestClient/motor_test_client.py
+++ b/AV00-Tests/PythonTestClient/motor_test_client.py
@@ -1,0 +1,44 @@
+
+import zmq
+import time
+from motor_event import *
+
+
+class RelayClient:
+    
+    def __init__(self):
+        self.context = zmq.Context()
+        self.socket = self.context.socket(zmq.PUSH)
+        self.socket.bind("tcp://localhost:5556")
+    
+    def send_motor_event(self, motor_event):
+        self.socket.send_multipart(motor_event.Serialize())
+
+class main:
+    
+    def __init__(self):
+        pass
+    
+
+
+if __name__ == "__main__":
+    relay_client = RelayClient()
+    
+    motor_event = MotorEvent(
+         ServiceName="DriveService",
+         Command=EnumMotorCommands.Move,
+         Direction=0,
+         PwmAmount=30.0,
+    )
+    relay_client.send_motor_event(motor_event)    
+    time.sleep(1)
+    
+    motor_event = MotorEvent(
+         ServiceName="DriveService",
+         Command=EnumMotorCommands.Move,
+         Direction=0,
+         PwmAmount=0.0,
+    )
+    relay_client.send_motor_event(motor_event)
+    
+    

--- a/AV00-Tests/PythonTestClient/motor_test_client.py
+++ b/AV00-Tests/PythonTestClient/motor_test_client.py
@@ -57,7 +57,7 @@ if __name__ == "__main__":
     motor_event = MotorEvent(
          ServiceName="DriveService",
          Command=EnumMotorCommands[cli.args.command].value,
-         Direction=cli.args.direction,
+         Direction=MotorDirection.__dict__[cli.args.direction],
          PwmAmount=float(cli.args.power),
     )
     relay_client.send_motor_event(motor_event)    

--- a/AV00-Tests/PythonTestClient/motor_test_client.py
+++ b/AV00-Tests/PythonTestClient/motor_test_client.py
@@ -20,7 +20,7 @@ class CLI:
         self.parser.add_argument(
             "-d",
             "--direction",
-            choices=[e.name for e in MotorDirection]
+            choices=list(vars(MotorDirection()).keys())
         )
         self.parser.add_argument(
             "-p",

--- a/AV00-Tests/PythonTestClient/motor_test_client.py
+++ b/AV00-Tests/PythonTestClient/motor_test_client.py
@@ -57,8 +57,8 @@ if __name__ == "__main__":
     motor_event = MotorEvent(
          ServiceName="DriveService",
          Command=EnumMotorCommands[cli.args.command].value,
-         Direction={},
-         PwmAmount=cli.args.power,
+         Direction=cli.args.direction,
+         PwmAmount=float(cli.args.power),
     )
     relay_client.send_motor_event(motor_event)    
     time.sleep(1)
@@ -70,5 +70,3 @@ if __name__ == "__main__":
          PwmAmount=0.0,
     )
     relay_client.send_motor_event(motor_event)
-    
-    

--- a/AV00-Tests/PythonTestClient/motor_test_client.py
+++ b/AV00-Tests/PythonTestClient/motor_test_client.py
@@ -13,7 +13,7 @@ class RelayClient:
     
     def send_motor_event(self, motor_event):
         event = Event(motor_event)
-        self.socket.send_multipart(event.Serialize())
+        self.socket.send_multipart(event.serialize())
 
 class main:
     

--- a/AV00-Tests/PythonTestClient/motor_test_client.py
+++ b/AV00-Tests/PythonTestClient/motor_test_client.py
@@ -9,10 +9,11 @@ class RelayClient:
     def __init__(self):
         self.context = zmq.Context()
         self.socket = self.context.socket(zmq.PUSH)
-        self.socket.bind("tcp://localhost:5556")
+        self.socket.connect("tcp://127.0.0.1:5556")
     
     def send_motor_event(self, motor_event):
-        self.socket.send_multipart(motor_event.Serialize())
+        event = Event(motor_event)
+        self.socket.send_multipart(event.Serialize())
 
 class main:
     

--- a/AV00-Tests/PythonTestClient/motor_test_client.py
+++ b/AV00-Tests/PythonTestClient/motor_test_client.py
@@ -57,7 +57,7 @@ if __name__ == "__main__":
     motor_event = MotorEvent(
          ServiceName="DriveService",
          Command=EnumMotorCommands[cli.args.command].value,
-         Direction=MotorDirection.__dict__[cli.args.direction],
+         Direction=MotorDirection().__dict__[cli.args.direction],
          PwmAmount=float(cli.args.power),
     )
     relay_client.send_motor_event(motor_event)    
@@ -66,7 +66,7 @@ if __name__ == "__main__":
     motor_event = MotorEvent(
          ServiceName="DriveService",
          Command=EnumMotorCommands.Move,
-         Direction={},
+         Direction=MotorDirection().__dict__[cli.args.direction],
          PwmAmount=0.0,
     )
     relay_client.send_motor_event(motor_event)

--- a/AV00-Tests/PythonTestClient/motor_test_client.py
+++ b/AV00-Tests/PythonTestClient/motor_test_client.py
@@ -28,7 +28,7 @@ if __name__ == "__main__":
     motor_event = MotorEvent(
          ServiceName="DriveService",
          Command=EnumMotorCommands.Move,
-         Direction=0,
+         Direction={},
          PwmAmount=30.0,
     )
     relay_client.send_motor_event(motor_event)    
@@ -37,7 +37,7 @@ if __name__ == "__main__":
     motor_event = MotorEvent(
          ServiceName="DriveService",
          Command=EnumMotorCommands.Move,
-         Direction=0,
+         Direction={},
          PwmAmount=0.0,
     )
     relay_client.send_motor_event(motor_event)

--- a/AV00-Tests/PythonTestClient/motor_test_client.py
+++ b/AV00-Tests/PythonTestClient/motor_test_client.py
@@ -56,9 +56,9 @@ if __name__ == "__main__":
     
     motor_event = MotorEvent(
          ServiceName="DriveService",
-         Command=EnumMotorCommands(cli.args["comman"]),
+         Command=EnumMotorCommands(cli.args.command),
          Direction={},
-         PwmAmount=cli.args["power"],
+         PwmAmount=cli.args.power,
     )
     relay_client.send_motor_event(motor_event)    
     time.sleep(1)

--- a/AV00-Tests/PythonTestClient/motor_test_client.py
+++ b/AV00-Tests/PythonTestClient/motor_test_client.py
@@ -56,7 +56,7 @@ if __name__ == "__main__":
     
     motor_event = MotorEvent(
          ServiceName="DriveService",
-         Command=EnumMotorCommands(cli.args.command),
+         Command=EnumMotorCommands[cli.args.command].value,
          Direction={},
          PwmAmount=cli.args.power,
     )

--- a/AV00/Controllers/MotorController/MotorCommandEventModel.cs
+++ b/AV00/Controllers/MotorController/MotorCommandEventModel.cs
@@ -39,9 +39,9 @@ namespace AV00.Controllers.MotorController
             EnumMotorDirection Direction,
             float PwmAmount,
             EnumExecutionMode Mode,
-            string Id,
+            Guid Id,
             string TimeStamp
-        ) : base(ServiceName, Guid.Parse(Id), TimeStamp)
+        ) : base(ServiceName, Id, TimeStamp)
         {
             command = Command;
             direction = Direction;

--- a/AV00/Controllers/MotorController/MotorCommandEventModel.cs
+++ b/AV00/Controllers/MotorController/MotorCommandEventModel.cs
@@ -1,6 +1,5 @@
 ﻿using AV00_Shared.FlowControl;
 using AV00_Shared.Models;
-using System.Device.Gpio;
 using System.Text.Json.Serialization;
 
 namespace AV00.Controllers.MotorController
@@ -8,8 +7,8 @@ namespace AV00.Controllers.MotorController
     [Serializable]
     public class MotorCommandEventModel : EventModel, IEventModel
     {
-        public PinValue Direction { get => direction; }
-        private readonly PinValue direction;
+        public EnumMotorDirection Direction { get => direction; }
+        private readonly EnumMotorDirection direction;
         public float PwmAmount { get => pwmAmount; }
         private readonly float pwmAmount;
         public EnumMotorCommands Command { get => command; }
@@ -20,7 +19,7 @@ namespace AV00.Controllers.MotorController
         public MotorCommandEventModel(
             string ServiceName,
             EnumMotorCommands Command,
-            PinValue Direction,
+            EnumMotorDirection Direction,
             float PwmAmount,
             EnumExecutionMode Mode = EnumExecutionMode.Blocking,
             Guid? Id = null,
@@ -37,7 +36,7 @@ namespace AV00.Controllers.MotorController
         public MotorCommandEventModel(
             string ServiceName,
             EnumMotorCommands Command,
-            PinValue Direction,
+            int Direction,
             float PwmAmount,
             EnumExecutionMode Mode,
             Guid Id,
@@ -45,7 +44,7 @@ namespace AV00.Controllers.MotorController
         ) : base(ServiceName, Id, TimeStamp)
         {
             command = Command;
-            direction = Direction;
+            direction = (EnumMotorDirection)Direction;
             pwmAmount = PwmAmount;
             mode = Mode;
         }

--- a/AV00/Controllers/MotorController/MotorCommandEventModel.cs
+++ b/AV00/Controllers/MotorController/MotorCommandEventModel.cs
@@ -39,12 +39,12 @@ namespace AV00.Controllers.MotorController
             int Direction,
             float PwmAmount,
             EnumExecutionMode Mode,
-            Guid Id,
+            string Id,
             string TimeStamp
-        ) : base(ServiceName, Id, TimeStamp)
+        ) : base(ServiceName, Guid.Parse(Id), TimeStamp)
         {
             command = Command;
-            direction = (EnumMotorDirection)Direction;
+            direction = (EnumMotorDirection)Enum.ToObject(typeof(EnumMotorDirection), Direction);
             pwmAmount = PwmAmount;
             mode = Mode;
         }

--- a/AV00/Controllers/MotorController/MotorCommandEventModel.cs
+++ b/AV00/Controllers/MotorController/MotorCommandEventModel.cs
@@ -36,7 +36,7 @@ namespace AV00.Controllers.MotorController
         public MotorCommandEventModel(
             string ServiceName,
             EnumMotorCommands Command,
-            int Direction,
+            EnumMotorDirection Direction,
             float PwmAmount,
             EnumExecutionMode Mode,
             string Id,
@@ -44,7 +44,7 @@ namespace AV00.Controllers.MotorController
         ) : base(ServiceName, Guid.Parse(Id), TimeStamp)
         {
             command = Command;
-            direction = (EnumMotorDirection)Enum.ToObject(typeof(EnumMotorDirection), Direction);
+            direction = Direction;
             pwmAmount = PwmAmount;
             mode = Mode;
         }

--- a/AV00/Controllers/MotorController/MotorControllers.cs
+++ b/AV00/Controllers/MotorController/MotorControllers.cs
@@ -18,17 +18,32 @@ namespace AV00.Controllers.MotorController
         }
     }
 
+    public enum EnumMotorDirection
+    {
+        Low,
+        High,
+    }
+
     public class MotorDirection
     {
-        private static readonly PinValue forwards = PinValue.High;
-        private static readonly PinValue backwards = PinValue.Low;
-        private static readonly PinValue left = PinValue.High;
-        private static readonly PinValue right = PinValue.Low;
+        private static readonly EnumMotorDirection forwards = EnumMotorDirection.High;
+        private static readonly EnumMotorDirection backwards = EnumMotorDirection.Low;
+        private static readonly EnumMotorDirection left = EnumMotorDirection.High;
+        private static readonly EnumMotorDirection right = EnumMotorDirection.Low;
+        public static EnumMotorDirection Forwards { get => forwards; }
+        public static EnumMotorDirection Backwards { get => backwards; }
+        public static EnumMotorDirection Left { get => left; }
+        public static EnumMotorDirection Right { get => right; }
+        private static Dictionary<EnumMotorDirection, PinValue> pinValues = new()
+        {
+            { EnumMotorDirection.High, PinValue.High },
+            { EnumMotorDirection.Low, PinValue.Low }
+        };
 
-        public static PinValue Forwards { get => forwards; }
-        public static PinValue Backwards { get => backwards; }
-        public static PinValue Left { get => left; }
-        public static PinValue Right { get => right; }
+        public static PinValue PinValueFromDirection(EnumMotorDirection MotorDirection)
+        {
+            return pinValues[MotorDirection];
+        }
     }
 
     public enum EnumMotorCommands
@@ -120,11 +135,11 @@ namespace AV00.Controllers.MotorController
             Token.ThrowIfCancellationRequested();
             IMotor RequestedMotor = motorRegistry[MotorRequest.Command].Motor;
             WriteLogFile(RequestedMotor, MotorRequest);
-            if (MotorRequest.Direction != RequestedMotor.CurrentDirection)
+            if (MotorDirection.PinValueFromDirection(MotorRequest.Direction) != RequestedMotor.CurrentDirection)
             {
                 GradualStop(RequestedMotor, MotorRequest, Token);
             }
-            RequestedMotor.CurrentDirection = MotorRequest.Direction;
+            RequestedMotor.CurrentDirection = MotorDirection.PinValueFromDirection(MotorRequest.Direction);
             if (MotorRequest.PwmAmount == RequestedMotor.CurrentPwmAmount) { return; }
             else if (MotorRequest.PwmAmount > RequestedMotor.CurrentPwmAmount)
             {

--- a/AV00/Controllers/MotorController/MotorControllers.cs
+++ b/AV00/Controllers/MotorController/MotorControllers.cs
@@ -192,7 +192,7 @@ namespace AV00.Controllers.MotorController
             if (Motor.CurrentPwmAmount < stopAmount) { Motor.CurrentPwmAmount = stopAmount; }
             if (targetPwm <= Motor.CurrentPwmAmount) { return; }
             float runAmount = (float)Math.Floor(Motor.PwmSoftCaps.RunPwm * servoBoardController.PwmMaxPercent);
-            Console.WriteLine($"Target= {targetPwm}, softCap= {runAmount}");
+            Console.WriteLine($"Target= {targetPwm}, softCap= {runAmount}, PwmSoftCaps.RunPw={Motor.PwmSoftCaps.RunPwm}, PwmMaxPercent={servoBoardController.PwmMaxPercent}");
             if (targetPwm > runAmount) { targetPwm = runAmount; }
             float pwmChangeAmount = (float)Math.Floor(servoBoardController.PwmMaxPercent * Motor.DutyCycleChangeStepPct);
             Console.WriteLine($"*DEBUG* MOTOR-CONTROLLER [Accelerate] Current speed {Motor.CurrentPwmAmount} Target speed {targetPwm} Stepping {pwmChangeAmount}");

--- a/AV00/Controllers/MotorController/MotorControllers.cs
+++ b/AV00/Controllers/MotorController/MotorControllers.cs
@@ -192,6 +192,7 @@ namespace AV00.Controllers.MotorController
             if (Motor.CurrentPwmAmount < stopAmount) { Motor.CurrentPwmAmount = stopAmount; }
             if (targetPwm <= Motor.CurrentPwmAmount) { return; }
             float runAmount = (float)Math.Floor(Motor.PwmSoftCaps.RunPwm * servoBoardController.PwmMaxPercent);
+            Console.WriteLine($"Target= {targetPwm}, softCap= {runAmount}");
             if (targetPwm > runAmount) { targetPwm = runAmount; }
             float pwmChangeAmount = (float)Math.Floor(servoBoardController.PwmMaxPercent * Motor.DutyCycleChangeStepPct);
             Console.WriteLine($"*DEBUG* MOTOR-CONTROLLER [Accelerate] Current speed {Motor.CurrentPwmAmount} Target speed {targetPwm} Stepping {pwmChangeAmount}");

--- a/AV00/Drivers/Motors/MDD10A.cs
+++ b/AV00/Drivers/Motors/MDD10A.cs
@@ -21,7 +21,7 @@ namespace AV00.Drivers.Motors
         public short DirectionPin { get; }
         public int PwmChannelId { get; }
         public float DutyCycleChangeStepPct { get; } = 0.01f;
-        public short DutyCycleChangeIntervalMs { get; } = 100;
+        public short DutyCycleChangeIntervalMs { get; } = 40;
         public string Name { get; set; }
         public PinValue CurrentDirection { get => currentDirection; set => currentDirection = value; }
         private PinValue currentDirection = PinValue.Low;
@@ -45,7 +45,7 @@ namespace AV00.Drivers.Motors
         public short DirectionPin { get; }
         public int PwmChannelId { get; }
         public float DutyCycleChangeStepPct { get; } = 0.01f;
-        public short DutyCycleChangeIntervalMs { get; } = 100;
+        public short DutyCycleChangeIntervalMs { get; } = 40;
         public string Name { get; set; }
         public PinValue CurrentDirection { get => currentDirection; set => currentDirection = value; }
         private PinValue currentDirection = PinValue.Low;

--- a/AV00/Program.cs
+++ b/AV00/Program.cs
@@ -43,7 +43,7 @@ namespace AV00
         public static void Main()
         {
             Console.WriteLine("Starting");
-            Console.WriteLine($"Pin High = {PinValue.High}, Pin Low = {PinValue.Low}");
+            Console.WriteLine($"Pin High = {PinValue.High.}, Pin Low = {PinValue.Low}");
             DeviceRegistryService deviceRegistry = new();
             ServiceRegistry.AddService(deviceRegistry);
 

--- a/AV00/Program.cs
+++ b/AV00/Program.cs
@@ -73,6 +73,12 @@ namespace AV00
             transportRelayThread.Start();
             driveServiceThread.Start();
 
+            
+            MotorCommandEventModel eventModel = new("DriveService", EnumMotorCommands.Move, MotorDirection.Forwards, 0f);
+            MotorEvent @event = new(eventModel);
+            Console.WriteLine($"PROGRAM: [Pushing] TaskEvent {@event.Id}");
+            transportClient.PushEvent(@event);
+
             /*
             MotorCommandEventModel eventModel = new("DriveService", EnumMotorCommands.Move, MotorDirection.Forwards, 30f);
             MotorEvent @event = new(eventModel);

--- a/AV00/Program.cs
+++ b/AV00/Program.cs
@@ -60,8 +60,8 @@ namespace AV00
             PDSGBGearboxMotorController motorController = new(
                 new GPIO(GpioControllerId),
                 pwmDriver,
-                new MDD10A39012(127, 1, "TurningMotor"),
-                new MDD10A55072(112, 0, "DriveMotor")
+                new MDD10A39012(127, 0, "TurningMotor"),
+                new MDD10A55072(112, 1, "DriveMotor")
             );
             Console.WriteLine($"STATUS: {DFR0604.LastOperationStatus}, REASON: {DFR0604.ErrorMessage}");
             DriveService driveService = new(motorController, ConfigurationManager.ConnectionStrings, ConfigurationManager.AppSettings);

--- a/AV00/Program.cs
+++ b/AV00/Program.cs
@@ -7,8 +7,6 @@ using AV00.Controllers.MotorController;
 using AV00.Drivers.IO;
 using AV00.Drivers.Motors;
 using AV00.Drivers.ExpansionBoards;
-using AV00.Communication;
-using AV00_Shared.FlowControl;
 using Transport.Client;
 
 namespace AV00
@@ -75,6 +73,7 @@ namespace AV00
             transportRelayThread.Start();
             driveServiceThread.Start();
 
+            /*
             MotorCommandEventModel eventModel = new("DriveService", EnumMotorCommands.Move, MotorDirection.Forwards, 30f);
             MotorEvent @event = new(eventModel);
             Console.WriteLine($"PROGRAM: [Pushing] TaskEvent {@event.Id}");
@@ -96,7 +95,10 @@ namespace AV00
             @event = new(eventModel);
             Console.WriteLine($"PROGRAM: [Pushing] TaskEvent {@event.Id}");
             transportClient.PushEvent(@event);
-            Console.WriteLine($"STATUS4: {DFR0604.LastOperationStatus}, REASON: {DFR0604.ErrorMessage}");
+
+            */
+
+
             var i = 0;
             while(!Console.KeyAvailable)
             {

--- a/AV00/Program.cs
+++ b/AV00/Program.cs
@@ -74,7 +74,7 @@ namespace AV00
             driveServiceThread.Start();
 
             
-            MotorCommandEventModel eventModel = new("DriveService", EnumMotorCommands.Move, MotorDirection.Forwards, 0f);
+            MotorCommandEventModel eventModel = new("DriveService", EnumMotorCommands.Move, MotorDirection.Backwards, 0f);
             MotorEvent @event = new(eventModel);
             Console.WriteLine($"PROGRAM: [Pushing] TaskEvent {@event.Id}");
             transportClient.PushEvent(@event);

--- a/AV00/Program.cs
+++ b/AV00/Program.cs
@@ -43,7 +43,7 @@ namespace AV00
         public static void Main()
         {
             Console.WriteLine("Starting");
-            Console.WriteLine($"Pin High = {PinValue.High.}, Pin Low = {PinValue.Low}");
+            Console.WriteLine($"Pin High = {PinValue.High}, Pin Low = {PinValue.Low}");
             DeviceRegistryService deviceRegistry = new();
             ServiceRegistry.AddService(deviceRegistry);
 

--- a/AV00/Program.cs
+++ b/AV00/Program.cs
@@ -8,6 +8,7 @@ using AV00.Drivers.IO;
 using AV00.Drivers.Motors;
 using AV00.Drivers.ExpansionBoards;
 using Transport.Client;
+using System.Device.Gpio;
 
 namespace AV00
 {
@@ -42,6 +43,7 @@ namespace AV00
         public static void Main()
         {
             Console.WriteLine("Starting");
+            Console.WriteLine($"Pin High = {PinValue.High}, Pin Low = {PinValue.Low}");
             DeviceRegistryService deviceRegistry = new();
             ServiceRegistry.AddService(deviceRegistry);
 


### PR DESCRIPTION
Added a python CLI to allow testing/running the motor service without re-compiling. It works by sending motorEvents directly to the zmq relay.